### PR TITLE
Safari+Firefox permission prompt

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,21 +1,17 @@
 <template>
   <div id="app">
-    <PermissionCheck>
-      <StoreManager />
-    </PermissionCheck>
+    <PermissionCheck />
   </div>
 </template>
 
 <script lang="ts">
 import Vue from "vue";
-import StoreManager from "./components/StoreManager.vue";
+
 import PermissionCheck from "./components/PermissionCheck.vue";
-import axios from "axios";
 
 export default Vue.extend({
   name: "app",
   components: {
-    StoreManager,
     PermissionCheck
   }
 });

--- a/src/assets/MapMarker.vue
+++ b/src/assets/MapMarker.vue
@@ -2,12 +2,13 @@
   <img class="marker" v-bind:src="imageSrc" alt="map marker" />
 </template>
 
-<script>
+<script lang="ts">
+import marker from "@/assets/marker.svg"
 export default {
   name: "MapMarker",
   data() {
     return {
-      imageSrc: require("@/assets/marker.svg")
+      imageSrc: marker
     };
   }
 };

--- a/src/components/StoreManager.vue
+++ b/src/components/StoreManager.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="!loadingStores && !loadingCoords">
+  <div v-if="!loadingStores">
     <Answer v-bind:stores="closestStores" />
     <StoreLister
       v-bind:closestStores="closestStores"
@@ -12,19 +12,18 @@
 </template>
 
 <script lang="ts">
-import Vue, { VNode } from "vue";
+import Vue from "vue";
 import axios from "axios";
 import { getDistance } from "geolib";
-import StoreInfo from "./StoreInfo.vue";
 import Answer from "./Answer.vue";
 import StoreLister from "./StoreLister.vue";
 import Loader from "./Loader.vue";
-import PermissionCheck from "./PermissionCheck.vue";
 import { type IStore } from "../types/customTypes";
 import { storeIsOpen } from "../mixins/locationMixins";
 
 export default Vue.extend({
   name: "StoreManager",
+  props: ["coordinates"],
   components: {
     Answer,
     StoreLister,
@@ -33,13 +32,11 @@ export default Vue.extend({
   data() {
     return {
       stores: [] as IStore[] | null,
-      loadingCoords: true,
       loadingStores: true,
       coords: {
         lat: "",
         lng: ""
       },
-      location: null as any
     };
   },
   methods: {
@@ -49,24 +46,11 @@ export default Vue.extend({
         .map(num => parseFloat(num));
       const storePos = { latitude: storeLat, longitude: storeLong };
       const currentPos = {
-        latitude: this.coords.lat,
-        longitude: this.coords.lng
+        latitude: this.$props.coordinates.lat,
+        longitude: this.$props.coordinates.lng
       }; // Lunner: { latitude: "60.267963", longitude: "10.566183" } Current: { latitude: this.coords.lat, longitude: this.coords.long }
       const distanceToStore = getDistance(storePos, currentPos);
       return distanceToStore;
-    },
-    async getCurrentLocation() {
-      // console.log("trying to fetch loc");
-      try {
-        const coordinates = await (this as any).$getLocation({
-          enableHighAccuracy: true
-        });
-        this.coords = coordinates;
-        // console.log("Fetched coords:", coordinates);
-        this.loadingCoords = false;
-      } catch (error) {
-        // console.log("failed", error);
-      }
     },
     async fetchStores() {
       //console.log("fetching stores");
@@ -123,12 +107,8 @@ export default Vue.extend({
     }
   },
   beforeMount() {
-    this.getCurrentLocation();
     this.fetchStores();
   },
-  mounted() {
-    //console.log("StoreManager mounted. Props:", this.$props);
-  }
 });
 </script>
 

--- a/src/mixins/locationMixins.ts
+++ b/src/mixins/locationMixins.ts
@@ -10,24 +10,11 @@ enum Ukedager {
   "søndag"
 }
 
-export enum PermissionStatus {
+export enum Permission {
   GRANTED = "granted",
   DENIED = "denied",
   PROMPT = "prompt"
 }
-
-export const hasPermission = async () => {
-  return navigator.permissions
-    .query({ name: "geolocation" })
-    .then(function(result) {
-      // console.log(result, result.state === "granted");
-      return result.state;
-    });
-};
-
-const timeToNumbers = (time: string) => {
-  return time.split(":").map(num => Number(num));
-};
 
 const timeToMinutes = (time: string) => {
   if (!time) {


### PR DESCRIPTION
Changes component layout so that website only asks for geolocation once. Safari and Firefox prompts the user every time geolocation is requested, and will refuse to ask for location if not triggered by a user interaction. 

![image](https://github.com/user-attachments/assets/7b3a8a37-bad1-451f-9c5b-7749d65726b7)
